### PR TITLE
Fix issue with jasny offside canvas menu dropdown links

### DIFF
--- a/browser/css/custom.css
+++ b/browser/css/custom.css
@@ -203,3 +203,6 @@ a{
     line-height: 1.7;
 }
 */
+
+/** Fix for issue in jasny offside canvas menu in dropdowns */
+.navmenu-nav.dropdown-menu { position: relative; }


### PR DESCRIPTION
There is a bug in jasny-bootstrap 3.1.3 that will be fixed in 3.1.4, meanwhile: 
https://github.com/jasny/bootstrap/issues/230
